### PR TITLE
Fixed issue-03: Horizontal section - item width exceeds sectionWidth of UICollectionView

### DIFF
--- a/CZInstagram/CZInstagram/Utils/ReactiveListViewKit/ReactiveListViewKit/ReactiveListViewKit/CZFeedListFacadeView.swift
+++ b/CZInstagram/CZInstagram/Utils/ReactiveListViewKit/ReactiveListViewKit/ReactiveListViewKit/CZFeedListFacadeView.swift
@@ -317,9 +317,17 @@ extension CZFeedListFacadeView: UICollectionViewDelegateFlowLayout {
             assertionFailure("Couldn't find matched cell/feedModel at \(indexPath)")
             return .zero
         }
+        
         // UICollectionView has .zero frame at this point
         let collectionViewSize = collectionView.bounds.size
-        let size = feedModel.viewClass.sizeThatFits(collectionViewSize, viewModel: feedModel.viewModel)
+        
+        // Adjust containerViewSize based on sectionInsets
+        var containerViewSize = collectionViewSize
+        if let sectionInset = viewModel.sectionModels[indexPath.section].sectionInset {
+            containerViewSize = CGSize(width: collectionViewSize.width - sectionInset.left - sectionInset.right,
+                                       height: collectionViewSize.height - sectionInset.top - sectionInset.bottom)
+        }
+        let size = feedModel.viewClass.sizeThatFits(containerViewSize, viewModel: feedModel.viewModel)
         return size
     }
 


### PR DESCRIPTION
https://github.com/geekaurora/CZInstagram/issues/3

Issue is caused by item width exceeds UICollectionView section size set

**Root Cause**
* Absent considering sectionInset when calculate item size of UICollectionView

**Solution**
- Adjust containerViewSize based on sectionInsets

**Error log:** 

> The behavior of the UICollectionViewFlowLayout is not defined because:
2017-10-16 18:15:10.119 CZInstagram[95275:16642278] the item width must be less than the width of the UICollectionView minus the section insets left and right values, minus the content insets left and right values.
2017-10-16 18:15:10.120 CZInstagram[95275:16642278] The relevant UICollectionViewFlowLayout instance is <UICollectionViewFlowLayout: 0x7fa0a680e7a0>, and it is attached to <UICollectionView: 0x7fa0a703be00; frame = (0 0; 414 672); clipsToBounds = YES; gestureRecognizers = <NSArray: 0x61800005f890>; layer = <CALayer: 0x61800003eb20>; contentOffset: {0, -60}; contentSize: {0, 0}> collection view layout: <UICollectionViewFlowLayout: 0x7fa0a680e7a0>.
2017-10-16 18:15:10.120 CZInstagram[95275:16642278] Make a symbolic breakpoint at UICollectionViewFlowLayoutBreakForInvalidSizes to catch this in the debugger.

